### PR TITLE
fix: downgrade intl with 3.10.0 to be compatible with flutter 3.10 (stable)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_parsed_text: ^2.2.1
-  intl: ^0.18.1
+  intl: ^0.18.0
   url_launcher: ^6.0.10
   video_player: ^2.2.5
 


### PR DESCRIPTION
Flutter 3.10 stable was released yesterday.

https://github.com/rustdesk/rustdesk/actions/runs/4954373043/jobs/8862807066?pr=4337

![image](https://github.com/SebastienBtr/Dash-Chat-2/assets/71636191/08fc2a93-8422-4f60-bfab-46689057b0e7)
