### PR TITLE
Update media_container.dart

### DIFF
--- a/lib/src/widgets/message_row/media_container.dart
+++ b/lib/src/widgets/message_row/media_container.dart
@@ -105,7 +105,7 @@ class MediaContainer extends StatelessWidget {
             final bool isImage = m.type == MediaType.image;
             return Container(
               color: Colors.transparent,
-              margin: const EdgeInsets.only(top: 5, right: 5),
+              margin: const EdgeInsets.only(top: 5.0, right: 5.0, bottom: 10.0),
               width: media.length > 1 && isImage ? gallerySize : null,
               height: media.length > 1 && isImage ? gallerySize : null,
               constraints: BoxConstraints(


### PR DESCRIPTION
Added bottom margin to media_container widget,  because there's no space between media and text, when the message contain both.

Result:
![Screenshot_20240226_153343](https://github.com/SebastienBtr/Dash-Chat-2/assets/16263958/a5449591-3ecd-47a8-92e8-4cd47ae16b02)
